### PR TITLE
Settings: GitHub Actions 자동 배포 워크플로우 구성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy to Oracle Cloud
+
+on:
+  workflow_dispatch: # Oracle VM 세팅 완료 후 push 트리거로 변경 예정
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Oracle Cloud VM에 SSH 배포
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.ORACLE_HOST }}
+          username: ${{ secrets.ORACLE_USER }}
+          key: ${{ secrets.ORACLE_SSH_KEY }}
+          script: |
+            cd ~/CampusMarket-AI
+            git pull origin main
+            docker compose up --build -d

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ build/
 *.pt
 *.onnx
 runs/
+
+memory/
+CLAUDE.md
+.claude/


### PR DESCRIPTION
- main 브랜치 push 시 Oracle Cloud VM에 SSH 자동 배포
- appleboy/ssh-action 사용 (git pull → docker compose up --build)
- GitHub Secrets 항목: ORACLE_HOST, ORACLE_USER, ORACLE_SSH_KEY
- Oracle VM 세팅 완료 전까지 수동 트리거(workflow_dispatch)로 임시 설정

## #️⃣ 연관된 이슈
- #2

## 📝 작업 내용
- main 브랜치 push 시 Oracle Cloud VM에 자동 배포되는 GitHub Actions 워크플로우 작성
- appleboy/ssh-action으로 SSH 접속 후 git pull → docker compose up --build 실행
- Oracle VM 세팅 완료 전까지 수동 트리거(workflow_dispatch)로 임시 설정